### PR TITLE
Fix subprocess deadlock

### DIFF
--- a/gmeutils/gpgclass.py
+++ b/gmeutils/gpgclass.py
@@ -237,9 +237,9 @@ class _GPG(_gmechild):
 									stdin=None,
 									stdout=subprocess.PIPE,
 									stderr=subprocess.PIPE )
-			p.wait()
+			outs, errs = p.communicate()
 
-			for line in p.stdout.readlines():
+			for line in outs.split(b'\n'):
 				res=line.decode(self.parent._encoding,unicodeerror).split(":")
 
 				if (res[0]=="pub"


### PR DESCRIPTION
A large enough keyring can cause a deadlock with subprocess.wait(); subprocess.communicate() avoids this.
See: https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait